### PR TITLE
Update to 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+- Removed dependency to old 'RegisterForControllerStateChanges' and 'RegisterForControllerCommandMessages' APIs to make the plugin compatible with the latest SteamOS versions. (Thanks to @Lexodeus)
+
 ## 1.0.3
 
 - Fixed "controller settings" page issue again.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Decky Brightness Bar
 
-A plugin for [Decky](https://decky.xyz/) that displays a customizable brightness bar when the brightness is changed with 'STEAM/QAM + LS up/down' shortcuts.
+A plugin for [Decky](https://decky.xyz/) that displays a customizable brightness bar when the brightness is changed.
 
 ![](https://raw.githubusercontent.com/rasitayaz/decky-brightness-bar/main/preview.jpg)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decky-brightness-bar",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A plugin for Decky that displays a brightness bar when the brightness is changed.",
   "scripts": {
     "build": "shx rm -rf dist && rollup -c",


### PR DESCRIPTION
- Removed dependency to old 'RegisterForControllerStateChanges' and 'RegisterForControllerCommandMessages' APIs to make the plugin compatible with the latest SteamOS versions. (Thanks to @Lexodeus)